### PR TITLE
updating rule to match with not vowel in second last name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,8 +2992,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "optional": true
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
             }
           }
         },
@@ -3119,8 +3118,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "optional": true
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
             }
           }
         },
@@ -3270,8 +3268,7 @@
         "jsbn": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "optional": true
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
         },
         "json-schema": {
           "version": "0.2.3",
@@ -3723,8 +3720,7 @@
         "tweetnacl": {
           "version": "0.14.5",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "optional": true
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "uid-number": {
           "version": "0.0.6",

--- a/src/natural-person-tdc-code.ts
+++ b/src/natural-person-tdc-code.ts
@@ -94,7 +94,7 @@ class NameCode {
   private firstVowelExcludingFirstCharacterOf(s: string): string {
     let result: RegExpExecArray | null = /[aeiou]/i.exec(s.slice(1))
     if (!result) {
-      throw new Error('')
+      return 'X'
     }
     return result[0]
   }

--- a/test/natural-person-tdc-code.test.ts
+++ b/test/natural-person-tdc-code.test.ts
@@ -127,6 +127,12 @@ describe('ten-digits-code (tdc-code) calculator', () => {
       naturalPersonTenDigitsCode(person('Marco Antonio', 'Cano', 'Barraza', 13, 12, 1970))
     ).toEqual('CABM701213')
   })
+
+  it('should replace with X if lastname hasnt intern Vowel', () => {
+    expect(naturalPersonTenDigitsCode(person('Andres', 'Ich', 'Rodriguez', 13, 12, 1970))).toEqual(
+      'IXRA701213'
+    )
+  })
 })
 
 function person(


### PR DESCRIPTION
Hay un problema al generar el RFC y al no haber una consideracion para la regla siguiente

Con dos apellidos, si el primer apellido no tiene vocal interna, se le asignará una "X" en la segunda posición.
Tomer referecias de esta  [RFC](https://cec.cele.unam.mx/include/howToRFC.php)


(Habia hecho el mismo PR )